### PR TITLE
Fix USB typo and inconsistency

### DIFF
--- a/Fingerprint Reader/README.md
+++ b/Fingerprint Reader/README.md
@@ -14,8 +14,8 @@ Mainboard documentation. The connector used is Kyocera 046809610110846+.
 | Pin | Signal      | Notes                        |
 |-----|-------------|------------------------------|
 | 1   | VBUS        | 5V                           |
-| 2   | USB_P       | USB data                     |
-| 3   | USB_N       | USB data                     |
+| 2   | USB_DP      | USB data                     |
+| 3   | USB_DM      | USB data                     |
 | 4   | GND         |                              |
 | 5   | FPR_CTRL    | Output (mask switch events)  |
 | 6   | SWITCH      | Open collector output        |

--- a/Mainboard/README.md
+++ b/Mainboard/README.md
@@ -225,9 +225,9 @@ counterclockwise. Amphenol connector numbering is shown in the "Conn" column.
 | 37  | 19   | TP_BOARD_ID |                              |
 | 38  | 32   | 5VS         | 5V, touchpad - see [2]       |
 | 39  | 20   | 5VALW       | 5V, fingerprint, see [3]     |
-| 40  | 31   | USB_N       | Fingerprint sensor USB       |
+| 40  | 31   | USB_DM      | Fingerprint sensor USB       |
 | 41  | 21   | GND         |                              |
-| 42  | 30   | USB_P       | Fingerprint sensor USB       |
+| 42  | 30   | USB_DP      | Fingerprint sensor USB       |
 | 43  | 22   | FPR_CTRL    | See [4]                      |
 | 44  | 29   | SWITCH      | Power button pin             |
 | 45  | 23   | FPR_LED_R   | Low-side control by the EC   |

--- a/Touchpad/README.md
+++ b/Touchpad/README.md
@@ -117,7 +117,7 @@ The ZIF connector for the FPC going to the Mainboard, using a ACES 51688-0510M-0
 | 41  | 5VALW      | Always on supply | 5V              |
 | 42  | USB_DM     |                  |                 |
 | 43  | GND        |                  |                 |
-| 44  | USP_DP     |                  |                 |
+| 44  | USB_DP     |                  |                 |
 | 45  | EC_CONTROL |                  |                 |
 | 46  | SWITCH     |                  |                 |
 | 47  | LED_R      |                  |                 |


### PR DESCRIPTION
See commits for the two replacements performed. The typo should 100% be fixed. 