### PR TITLE
Clarify and correct the FPR_LED pinouts

### DIFF
--- a/Mainboard/README.md
+++ b/Mainboard/README.md
@@ -230,9 +230,9 @@ counterclockwise. Amphenol connector numbering is shown in the "Conn" column.
 | 42  | 30   | USB_DP      | Fingerprint sensor USB       |
 | 43  | 22   | FPR_CTRL    | See [4]                      |
 | 44  | 29   | SWITCH      | Power button pin             |
-| 45  | 23   | FPR_LED_R   | Low-side control by the EC   |
-| 46  | 28   | FPR_LED_W   | Low-side control by the EC   |
-| 47  | 24   | FPR_LED_G   | Low-side control by the EC   |
+| 45  | 23   | FPR_LED_W   | See [5]                      |
+| 46  | 28   | FPR_LED_R   | See [5]                      |
+| 47  | 24   | FPR_LED_G   | See [5]                      |
 | 48  | 27   | FPR_LED_COM | 5V, fingerprint LED, see [3] |
 | 49  | 25   | GND         |                              |
 | 50  | 26   | NC          |                              |
@@ -241,6 +241,7 @@ counterclockwise. Amphenol connector numbering is shown in the "Conn" column.
 - [2] Connected to the +5VS (switched) rail through a 0 ohm resistor
 - [3] Connected to the +5VALW (always-on) rail through a 0 ohm resistor
 - [4] FPR_CTRL is used to filter out power button presses while the fingerprint sensor is scanning
+- [5] The EC drives these LED's through low-side transistors. The RGB channels from the EC drive the white, green, and red fingerprint LED's, respectively.
 
 ## Fan Interface
 

--- a/Touchpad/README.md
+++ b/Touchpad/README.md
@@ -120,8 +120,10 @@ The ZIF connector for the FPC going to the Mainboard, using a ACES 51688-0510M-0
 | 44  | USB_DP     |                  |                 |
 | 45  | EC_CONTROL |                  |                 |
 | 46  | SWITCH     |                  |                 |
-| 47  | LED_R      |                  |                 |
-| 48  | LED_G      |                  |                 |
-| 49  | LED_B      |                  |                 |
+| 47  | LED_R      | See [1]          |                 |
+| 48  | LED_G      | See [1]          |                 |
+| 49  | LED_B      | See [1]          |                 |
 | 50  | LED_COM    |                  | 5V              |
 | 51  | Reserved   | Not connected    |                 |
+
+- [1] The mainboard EC drives these LED's through low-side transistors. The RGB channels from the EC drive the white, green, and red fingerprint LED's, respectively.


### PR DESCRIPTION
I tried creating my own power LED for use in the standalone CoolerMaster case, but the board did not work correctly. After extensive debugging, it turns out that documetation has `FPR_LED_W` and `FPR_LED_R` reversed (verified with an ohmmeter on a physical input cover). Flip them back the right way, and document the RGB -> WGR channel mapping that is taking place.