### PR TITLE
fix: correct two typos in README files

### DIFF
--- a/Fingerprint Reader/README.md
+++ b/Fingerprint Reader/README.md
@@ -7,7 +7,7 @@ To view a copy of this license, visit http://creativecommons.org/licenses/by/4.0
 
 ## Pinout
 
-The Fingerprint Reader resides on the Input Cover and connects though the Touchpad.
+The Fingerprint Reader resides on the Input Cover and connects through the Touchpad.
 All of its signals are directly passed to the Input Cover Interface described in the
 Mainboard documentation. The connector used is Kyocera 046809610110846+.
 

--- a/Mainboard/README.md
+++ b/Mainboard/README.md
@@ -269,7 +269,7 @@ For example, CR2032 MUST NOT be used, it cannot be charged and will likely be da
 
 RTC battery is used for storing persistent but resettable information.
 This includes the time and DRAM training. Disconnection will result in deletion of that information.
-If no battery is connection, DRAM training needs to happen on every boot, slowing down the boot process significantly.
+If no battery is connected, DRAM training needs to happen on every boot, slowing down the boot process significantly.
 
 ### Onboard RTC Battery
 


### PR DESCRIPTION
Fix two typos found in the documentation

- `Fingerprint Reader/README.md`: "connects though" → "connects through"
- `Mainboard/README.md`: "no battery is connection" → "no battery is connected"